### PR TITLE
Add recapScreenIconAlignment() view modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,18 +99,19 @@ Recap provides various modifiers to tailor the Releases screen to your app's vis
 
 ```swift
 // Available customization modifiers
-func recapStartIndex(_ startIndex: RecapScreenStartIndex) -> some View
-func recapTitleStyle(_ style: some ShapeStyle) -> some View
-func recapDismissButtonStyle(_ style: some ShapeStyle) -> some View
-func recapDismissButtonStyle(_ backgroundStyle: some ShapeStyle, _ foregroundStyle: some ShapeStyle) -> some View
-func recapIconFillMode(_ style: IconFillMode) -> some View
-func recapPageIndicatorColors(selected: Color, deselected: Color) -> some View
-func recapBackground(_ style: AnyShapeStyle?) -> some View
-func recapBackground(_ color: Color) -> some View
-func recapPadding(_ insets: EdgeInsets) -> some View
-func recapHeaderSpacing(_ spacing: CGFloat) -> some View
-func recapItemSpacing(_ spacing: CGFloat) -> some View
-func recapDismissAction(_ dismissAction: (() -> Void)?) -> some View
+func recapScreenStartIndex(_ startIndex: RecapScreenStartIndex) -> some View
+func recapScreenTitleStyle(_ style: some ShapeStyle) -> some View
+func recapScreenDismissButtonStyle(_ style: some ShapeStyle) -> some View
+func recapScreenDismissButtonStyle(_ backgroundStyle: some ShapeStyle, _ foregroundStyle: some ShapeStyle) -> some View
+func recapScreenIconFillMode(_ style: IconFillMode) -> some View
+func recapScreenIconAlignment(_ alignment: VerticalAlignment) -> some View
+func recapScreenPageIndicatorColors(selected: Color, deselected: Color) -> some View
+func recapScreenBackground(_ style: AnyShapeStyle?) -> some View
+func recapScreenBackground(_ color: Color) -> some View
+func recapScreenPadding(_ insets: EdgeInsets) -> some View
+func recapScreenHeaderSpacing(_ spacing: CGFloat) -> some View
+func recapScreenItemSpacing(_ spacing: CGFloat) -> some View
+func recapScreenDismissAction(_ dismissAction: (() -> Void)?) -> some View
 ```
 
 Example usage:

--- a/Sources/Recap/Internal/FeatureRow.swift
+++ b/Sources/Recap/Internal/FeatureRow.swift
@@ -2,12 +2,13 @@ import SwiftUI
 
 struct FeatureRow: View {
     @Environment(\.recapScreenIconFillMode) private var iconFillMode
+    @Environment(\.recapScreenIconAlignment) private var iconAlignment
 
     let feature: Feature
 
     var body: some View {
-        HStack(alignment: .center, spacing: 16.0) {
-            ZStack(alignment: .center) {
+        HStack(alignment: iconAlignment, spacing: 16.0) {
+            ZStack(alignment: Alignment(horizontal: .center, vertical: iconAlignment)) {
                 Color.clear
                     .frame(width: 48.0, height: 48.0)
 

--- a/Sources/Recap/Public/View+Recap.swift
+++ b/Sources/Recap/Public/View+Recap.swift
@@ -37,6 +37,11 @@ public extension View {
     func recapScreenIconFillMode(_ style: IconFillMode) -> some View {
         self.environment(\.recapScreenIconFillMode, style)
     }
+    
+    /// Configures the vertical alignment of a feature's icon displayed on the `RecapScreen`.
+    func recapScreenIconAlignment(_ alignment: VerticalAlignment) -> some View {
+        self.environment(\.recapScreenIconAlignment, alignment)
+    }
 
     /// Configures the `selected` and `deselected` state page indicator colors displayed on the `RecapScreen`.
     func recapScreenPageIndicatorColors(selected: Color, deselected: Color) -> some View {
@@ -162,6 +167,17 @@ internal extension EnvironmentValues {
 
     private struct IconFillModeKey: EnvironmentKey {
         static let defaultValue = IconFillMode.solid
+    }
+
+    // MARK: IconVerticalAlignment
+
+    var recapScreenIconAlignment: VerticalAlignment {
+        get { self[IconAlignmentKey.self] }
+        set { self[IconAlignmentKey.self] = newValue }
+    }
+
+    private struct IconAlignmentKey: EnvironmentKey {
+        static let defaultValue = VerticalAlignment.center
     }
 
     // MARK: PaddingKey


### PR DESCRIPTION
This PR is a different implementation of @AndyQ's PR "Added ability to specify vertical alignment for image against text" here: https://github.com/mergesort/Recap/pull/4.

Rather than adding the alignment as an attribute in the Markdown, it is instead applied via the view modifier `.recapScreenIconAlignment()`. The default value is `.center` to maintain behaviour from before this code is merged.

Screenshot from an iPad with the `.top` alignment.

<img width="521" alt="image" src="https://github.com/user-attachments/assets/9d99f663-f1d5-46f3-be78-fcb5465016d6">
