### PR TITLE
Add support for iOS 16 and Mac Catalyst 16

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "Recap",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v17)
+        .iOS(.v16), .macCatalyst(.v16)
     ],
     products: [
         .library(

--- a/Sources/Recap/Internal/ReleaseView.swift
+++ b/Sources/Recap/Internal/ReleaseView.swift
@@ -27,9 +27,22 @@ struct ReleaseView: View {
                 .padding(.leading, self.padding.leading)
                 .padding(.trailing, self.padding.trailing)
             }
-            .scrollBounceBehavior(.basedOnSize)
+            .withSizedBasedBounceBehaviorIfAvailable()
         }
         .padding(.top, self.padding.top)
         .padding(.bottom, self.padding.bottom)
+    }
+}
+
+// MARK: ScrollView
+
+fileprivate extension ScrollView {
+    func withSizedBasedBounceBehaviorIfAvailable() -> some View {
+        guard #available(iOS 16.4, macCatalyst 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4, *) else {
+            return self
+        }
+
+        return self
+            .scrollBounceBehavior(.basedOnSize)
     }
 }


### PR DESCRIPTION
This simple PR adds support for iOS (and Mac Catalyst) 16.

The only problem appears to be the `.scrollBounceBehavior()` modifier, which I've pulled out into a compatibility-wrapped function.