### PR TITLE
Add bottom padding on devices with no bottom safe area, fix button interaction area

### DIFF
--- a/Sources/Recap/Public/RecapScreen.swift
+++ b/Sources/Recap/Public/RecapScreen.swift
@@ -107,7 +107,12 @@ private extension View {
         #if os(macOS)
         return false
         #else
-        return (UIApplication.shared.windows.first?.safeAreaInsets.bottom ?? 0.0) > 0.0
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            // On iPad, we don't display fullscreen so the home bar isn't relevant.
+            return false
+        } else {
+            return (UIApplication.shared.windows.first?.safeAreaInsets.bottom ?? 0.0) > 0.0
+        }
         #endif
     }
 

--- a/Sources/Recap/Public/RecapScreen.swift
+++ b/Sources/Recap/Public/RecapScreen.swift
@@ -45,43 +45,49 @@ public struct RecapScreen<LeadingView: View, TrailingView: View>: View {
 
     public var body: some View {
         NavigationStack {
-            TabView(selection: $selectedIndex) {
-                self.leadingView
-                    .tag(self.tabIndex(from: .leadingView))
+            VStack(spacing: 0.0) {
+                TabView(selection: $selectedIndex) {
+                    self.leadingView
+                        .tag(self.tabIndex(from: .leadingView))
 
-                ForEach(self.displayedReleases) { release in
-                    ReleaseView(release: release)
-                        .padding(.bottom, 32.0)
-                        .tag((self.tabIndex(from: .release(
-                            self.displayedReleases.firstIndex(of: release) ?? 0)
-                        )))
+                    ForEach(self.displayedReleases) { release in
+                        ReleaseView(release: release)
+                            .padding(.bottom, 32.0)
+                            .tag((self.tabIndex(from: .release(
+                                self.displayedReleases.firstIndex(of: release) ?? 0)
+                            )))
+                    }
+
+                    self.trailingView
+                        .tag(self.tabIndex(from: .trailingView))
                 }
+                .tabViewStyle(.page(indexDisplayMode: self.releases.count > 1 ? .always : .never))
+                .background(self.derivedBackgroundStyle)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar(.hidden, for: .navigationBar)
 
-                self.trailingView
-                    .tag(self.tabIndex(from: .trailingView))
-            }
-            .tabViewStyle(.page(indexDisplayMode: self.releases.count > 1 ? .always : .never))
-            .background(self.derivedBackgroundStyle)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar(.hidden, for: .navigationBar)
-            .toolbar {
-                ToolbarItem(placement: .bottomBar) {
-                    Button(action: {
-                        dismissAction?() ?? dismiss()
-                    }, label: {
+                Button(action: {
+                    dismissAction?() ?? dismiss()
+                }, label: {
+                    HStack {
+                        Spacer(minLength: 0.0)
                         Text("RECAP.SCREEN.DISMISS.BUTTON.TITLE", bundle: .module)
                             .font(.system(.title3, weight: .bold))
                             .padding(8.0)
                             .padding(.vertical, 4.0)
                             .padding(.horizontal, 16.0)
                             .foregroundStyle(dismissButtonStyle.foregroundStyle)
-                    })
-                    .frame(maxWidth: .infinity)
-                    .background(self.dismissButtonStyle.backgroundStyle)
-                    .clipShape(.rect(cornerRadius: 16.0))
-                    .padding(.horizontal, 20.0)
-                    .foregroundStyle(.primary)
-                }
+                        Spacer(minLength: 0.0)
+                    }
+                    .contentShape(.rect(cornerRadius: 16.0))
+                    .frame(height: 54.0)
+                })
+                .frame(maxWidth: .infinity)
+                .background(self.dismissButtonStyle.backgroundStyle)
+                .clipShape(.rect(cornerRadius: 16.0))
+                .padding(.horizontal, 40.0)
+                .foregroundStyle(.primary)
+                .withBottomPaddingIfNoSafeArea()
             }
             .onAppear(perform: {
                 self.selectedIndex = self.tabIndex(from: self.startIndex)
@@ -93,6 +99,21 @@ public struct RecapScreen<LeadingView: View, TrailingView: View>: View {
                 self.teardownAppearanceChanges()
             })
         }
+    }
+}
+
+private extension View {
+    var hasSafeAreaForBottomPadding: Bool {
+        #if os(macOS)
+        return false
+        #else
+        return (UIApplication.shared.windows.first?.safeAreaInsets.bottom ?? 0.0) > 0.0
+        #endif
+    }
+
+    func withBottomPaddingIfNoSafeArea() -> some View {
+        guard !hasSafeAreaForBottomPadding else { return self }
+        return self.padding(.bottom, 20.0)
     }
 }
 

--- a/Sources/Recap/Public/RecapScreen.swift
+++ b/Sources/Recap/Public/RecapScreen.swift
@@ -44,51 +44,49 @@ public struct RecapScreen<LeadingView: View, TrailingView: View>: View {
     }
 
     public var body: some View {
-        NavigationStack {
-            VStack(spacing: 0.0) {
-                TabView(selection: $selectedIndex) {
-                    self.leadingView
-                        .tag(self.tabIndex(from: .leadingView))
+        VStack(spacing: 0.0) {
+            TabView(selection: $selectedIndex) {
+                self.leadingView
+                    .tag(self.tabIndex(from: .leadingView))
 
-                    ForEach(self.displayedReleases) { release in
-                        ReleaseView(release: release)
-                            .padding(.bottom, 32.0)
-                            .tag((self.tabIndex(from: .release(
-                                self.displayedReleases.firstIndex(of: release) ?? 0)
-                            )))
-                    }
-
-                    self.trailingView
-                        .tag(self.tabIndex(from: .trailingView))
+                ForEach(self.displayedReleases) { release in
+                    ReleaseView(release: release)
+                        .padding(.bottom, 32.0)
+                        .tag((self.tabIndex(from: .release(
+                            self.displayedReleases.firstIndex(of: release) ?? 0)
+                        )))
                 }
-                .tabViewStyle(.page(indexDisplayMode: self.releases.count > 1 ? .always : .never))
-                .background(self.derivedBackgroundStyle)
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar(.hidden, for: .navigationBar)
 
-                Button(action: {
-                    dismissAction?() ?? dismiss()
-                }, label: {
-                    HStack {
-                        Spacer(minLength: 0.0)
-                        Text("RECAP.SCREEN.DISMISS.BUTTON.TITLE", bundle: .module)
-                            .font(.system(.title3, weight: .bold))
-                            .padding(8.0)
-                            .padding(.vertical, 4.0)
-                            .padding(.horizontal, 16.0)
-                            .foregroundStyle(dismissButtonStyle.foregroundStyle)
-                        Spacer(minLength: 0.0)
-                    }
-                    .contentShape(.rect(cornerRadius: 16.0))
-                    .frame(height: 54.0)
-                })
-                .frame(maxWidth: .infinity)
-                .background(self.dismissButtonStyle.backgroundStyle)
-                .clipShape(.rect(cornerRadius: 16.0))
-                .padding(.horizontal, 40.0)
-                .foregroundStyle(.primary)
-                .withBottomPaddingIfNoSafeArea()
+                self.trailingView
+                    .tag(self.tabIndex(from: .trailingView))
             }
+            .tabViewStyle(.page(indexDisplayMode: self.releases.count > 1 ? .always : .never))
+            .background(self.derivedBackgroundStyle)
+
+            Button(action: {
+                dismissAction?() ?? dismiss()
+            }, label: {
+                HStack {
+                    Spacer(minLength: 0.0)
+
+                    Text("RECAP.SCREEN.DISMISS.BUTTON.TITLE", bundle: .module)
+                        .font(.system(.title3, weight: .bold))
+                        .padding(8.0)
+                        .padding(.vertical, 4.0)
+                        .padding(.horizontal, 16.0)
+                        .foregroundStyle(dismissButtonStyle.foregroundStyle)
+
+                    Spacer(minLength: 0.0)
+                }
+                .contentShape(.rect(cornerRadius: 16.0))
+            })
+            .frame(maxWidth: .infinity)
+            .background(self.dismissButtonStyle.backgroundStyle)
+            .clipShape(.rect(cornerRadius: 16.0))
+            .padding(.horizontal, 40.0)
+            .foregroundStyle(.primary)
+            .withBottomPaddingIfNoSafeArea()
+            .background(self.derivedBackgroundStyle)
             .onAppear(perform: {
                 self.selectedIndex = self.tabIndex(from: self.startIndex)
             })
@@ -102,25 +100,33 @@ public struct RecapScreen<LeadingView: View, TrailingView: View>: View {
     }
 }
 
-private extension View {
-    var hasSafeAreaForBottomPadding: Bool {
-        #if os(macOS)
-        return false
-        #else
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            // On iPad, we don't display fullscreen so the home bar isn't relevant.
-            return false
-        } else {
-            return (UIApplication.shared.windows.first?.safeAreaInsets.bottom ?? 0.0) > 0.0
-        }
-        #endif
-    }
+// MARK: Convenience Initializers
 
-    func withBottomPaddingIfNoSafeArea() -> some View {
-        guard !hasSafeAreaForBottomPadding else { return self }
-        return self.padding(.bottom, 20.0)
+public extension RecapScreen where LeadingView == EmptyView {
+    init(releases: [Release], @ViewBuilder trailingView: () -> TrailingView) {
+        self.releases = releases
+        self.leadingView = EmptyView()
+        self.trailingView = trailingView()
     }
 }
+
+public extension RecapScreen where TrailingView == EmptyView {
+    init(releases: [Release], @ViewBuilder leadingView: () -> LeadingView) {
+        self.releases = releases
+        self.leadingView = leadingView()
+        self.trailingView = EmptyView()
+    }
+}
+
+public extension RecapScreen where LeadingView == EmptyView, TrailingView == EmptyView {
+    init(releases: [Release]) {
+        self.releases = releases
+        self.leadingView = EmptyView()
+        self.trailingView = EmptyView()
+    }
+}
+
+// MARK: Private
 
 private extension RecapScreen {
     var displayedReleases: [Release] {
@@ -162,28 +168,24 @@ private extension RecapScreen {
     }
 }
 
-// MARK: Convenience Initializers
+// MARK: Safe Area Insets
 
-public extension RecapScreen where LeadingView == EmptyView {
-    init(releases: [Release], @ViewBuilder trailingView: () -> TrailingView) {
-        self.releases = releases
-        self.leadingView = EmptyView()
-        self.trailingView = trailingView()
+private extension View {
+    var hasSafeAreaForBottomPadding: Bool {
+#if os(macOS)
+        return false
+#else
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            // On iPad, we don't display fullscreen so the home bar isn't relevant.
+            return false
+        } else {
+            return (UIApplication.shared.windows.first?.safeAreaInsets.bottom ?? 0.0) > 0.0
+        }
+#endif
     }
-}
 
-public extension RecapScreen where TrailingView == EmptyView {
-    init(releases: [Release], @ViewBuilder leadingView: () -> LeadingView) {
-        self.releases = releases
-        self.leadingView = leadingView()
-        self.trailingView = EmptyView()
-    }
-}
-
-public extension RecapScreen where LeadingView == EmptyView, TrailingView == EmptyView {
-    init(releases: [Release]) {
-        self.releases = releases
-        self.leadingView = EmptyView()
-        self.trailingView = EmptyView()
+    func withBottomPaddingIfNoSafeArea() -> some View {
+        guard !hasSafeAreaForBottomPadding else { return self }
+        return self.padding(.bottom, 24.0)
     }
 }


### PR DESCRIPTION
This is a fix for https://github.com/mergesort/Recap/issues/13.

This PR adds bottom padding to the "Continue" button when it's shown in contexts where there isn't a bottom safe area to provide it (older iPhones, all iPads, all Macs).

SwiftUI doesn't deal with this very well, so we have to dip into UIKit a little bit _and_ pull the button out of the bottom toolbar and into a VStack with the main content. Another drawback of my approach is that it doesn't read the _view's_ safe area margins, but relies on the device's. This means it's not very flexible to different presentation styles by the client. Can you read and act on a view's safe area margins in SwiftUI?

**Bonus bugfix:** This also fixes the fact the "Continue" button only reacted to taps on the text.

Before/After iPad:

<img width="1127" alt="BAiPad" src="https://github.com/user-attachments/assets/0ebe8955-ecfc-45ac-97b0-d2c9220825bb">

Before/After iPhone SE:

![BALittleiPhone](https://github.com/user-attachments/assets/90e81fa3-e2d0-4412-b911-15bed6f3d68a)

Before/After iPhone 15 (note the minor visual difference due to the button not being in a toolbar any more):

![BAiPhone15](https://github.com/user-attachments/assets/08acdb17-d76c-422a-bfc9-a2f25fd88be2)

