### PR TITLE
Add ability to customise the dismiss button's title

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ func recapScreenStartIndex(_ startIndex: RecapScreenStartIndex) -> some View
 func recapScreenTitleStyle(_ style: some ShapeStyle) -> some View
 func recapScreenDismissButtonStyle(_ style: some ShapeStyle) -> some View
 func recapScreenDismissButtonStyle(_ backgroundStyle: some ShapeStyle, _ foregroundStyle: some ShapeStyle) -> some View
+func recapScreenDismissButtonTitle(_ titleKey: LocalizedStringKey, in bundle: Bundle, tableName: String?) -> some View
+func recapScreenDismissButtonTitle(_ title: String) -> some View
 func recapScreenIconFillMode(_ style: IconFillMode) -> some View
 func recapScreenIconAlignment(_ alignment: VerticalAlignment) -> some View
 func recapScreenPageIndicatorColors(selected: Color, deselected: Color) -> some View

--- a/README.md
+++ b/README.md
@@ -106,8 +106,7 @@ func recapScreenStartIndex(_ startIndex: RecapScreenStartIndex) -> some View
 func recapScreenTitleStyle(_ style: some ShapeStyle) -> some View
 func recapScreenDismissButtonStyle(_ style: some ShapeStyle) -> some View
 func recapScreenDismissButtonStyle(_ backgroundStyle: some ShapeStyle, _ foregroundStyle: some ShapeStyle) -> some View
-func recapScreenDismissButtonTitle(_ titleKey: LocalizedStringKey, in bundle: Bundle, tableName: String?) -> some View
-func recapScreenDismissButtonTitle(_ title: String) -> some View
+func recapScreenDismissButtonTitle(_ title: LocalizedStringResource) -> some View
 func recapScreenIconFillMode(_ style: IconFillMode) -> some View
 func recapScreenIconAlignment(_ alignment: VerticalAlignment) -> some View
 func recapScreenPageIndicatorColors(selected: Color, deselected: Color) -> some View

--- a/Sources/Recap/Internal/RecapLocalizedStringKey.swift
+++ b/Sources/Recap/Internal/RecapLocalizedStringKey.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+struct RecapLocalizedStringKey {
+    let key: LocalizedStringKey
+    let bundle: Bundle
+    let tableName: String?
+}

--- a/Sources/Recap/Internal/RecapLocalizedStringKey.swift
+++ b/Sources/Recap/Internal/RecapLocalizedStringKey.swift
@@ -1,7 +1,0 @@
-import SwiftUI
-
-struct RecapLocalizedStringKey {
-    let key: LocalizedStringKey
-    let bundle: Bundle
-    let tableName: String?
-}

--- a/Sources/Recap/Public/RecapScreen.swift
+++ b/Sources/Recap/Public/RecapScreen.swift
@@ -27,6 +27,8 @@ public struct RecapScreen<LeadingView: View, TrailingView: View>: View {
     @Environment(\.recapScreenSelectedPageIndicatorColor) private var selectedPageIndicatorColor
     @Environment(\.recapScreenDeselectedPageIndicatorColor) private var deselectedPageIndicatorColor
     @Environment(\.recapScreenDismissButtonStyle) private var dismissButtonStyle
+    @Environment(\.recapScreenDismissButtonTitle) private var dismissButtonCustomTitle
+    @Environment(\.recapScreenDismissButtonStringTitle) private var dismissButtonCustomStringTitle
     @Environment(\.recapScreenDismissAction) private var dismissAction
 
     @State private var originalSelectedPageIndicatorColor: UIColor?
@@ -69,7 +71,7 @@ public struct RecapScreen<LeadingView: View, TrailingView: View>: View {
                 HStack {
                     Spacer(minLength: 0.0)
 
-                    Text("RECAP.SCREEN.DISMISS.BUTTON.TITLE", bundle: .module)
+                    dismissButtonLabel
                         .font(.system(.title3, weight: .bold))
                         .padding(8.0)
                         .padding(.vertical, 4.0)
@@ -131,6 +133,14 @@ public extension RecapScreen where LeadingView == EmptyView, TrailingView == Emp
 private extension RecapScreen {
     var displayedReleases: [Release] {
         self.releases.reversed()
+    }
+
+    var dismissButtonLabel: Text {
+        if let dismissButtonCustomStringTitle {
+            Text(verbatim: dismissButtonCustomStringTitle)
+        } else {
+            Text(dismissButtonCustomTitle.key, tableName: dismissButtonCustomTitle.tableName, bundle: dismissButtonCustomTitle.bundle)
+        }
     }
 
     var derivedBackgroundStyle: AnyShapeStyle {

--- a/Sources/Recap/Public/RecapScreen.swift
+++ b/Sources/Recap/Public/RecapScreen.swift
@@ -27,8 +27,7 @@ public struct RecapScreen<LeadingView: View, TrailingView: View>: View {
     @Environment(\.recapScreenSelectedPageIndicatorColor) private var selectedPageIndicatorColor
     @Environment(\.recapScreenDeselectedPageIndicatorColor) private var deselectedPageIndicatorColor
     @Environment(\.recapScreenDismissButtonStyle) private var dismissButtonStyle
-    @Environment(\.recapScreenDismissButtonTitle) private var dismissButtonCustomTitle
-    @Environment(\.recapScreenDismissButtonStringTitle) private var dismissButtonCustomStringTitle
+    @Environment(\.recapScreenDismissButtonTitle) private var dismissButtonTitle
     @Environment(\.recapScreenDismissAction) private var dismissAction
 
     @State private var originalSelectedPageIndicatorColor: UIColor?
@@ -71,7 +70,7 @@ public struct RecapScreen<LeadingView: View, TrailingView: View>: View {
                 HStack {
                     Spacer(minLength: 0.0)
 
-                    dismissButtonLabel
+                    Text(dismissButtonTitle)
                         .font(.system(.title3, weight: .bold))
                         .padding(8.0)
                         .padding(.vertical, 4.0)
@@ -133,14 +132,6 @@ public extension RecapScreen where LeadingView == EmptyView, TrailingView == Emp
 private extension RecapScreen {
     var displayedReleases: [Release] {
         self.releases.reversed()
-    }
-
-    var dismissButtonLabel: Text {
-        if let dismissButtonCustomStringTitle {
-            Text(verbatim: dismissButtonCustomStringTitle)
-        } else {
-            Text(dismissButtonCustomTitle.key, tableName: dismissButtonCustomTitle.tableName, bundle: dismissButtonCustomTitle.bundle)
-        }
     }
 
     var derivedBackgroundStyle: AnyShapeStyle {

--- a/Sources/Recap/Public/View+Recap.swift
+++ b/Sources/Recap/Public/View+Recap.swift
@@ -34,13 +34,8 @@ public extension View {
     }
 
     /// Configures a custom localized title for the `RecapScreen` dismiss button.
-    func recapScreenDismissButtonTitle(_ titleKey: LocalizedStringKey, in bundle: Bundle = .main, tableName: String? = nil) -> some View {
-        self.environment(\.recapScreenDismissButtonTitle, RecapLocalizedStringKey(key: titleKey, bundle: bundle, tableName: tableName))
-    }
-
-    /// Configures a custom, non-localized title for the `RecapScreen` dismiss button.
-    func recapScreenDismissButtonTitle(_ title: String) -> some View {
-        self.environment(\.recapScreenDismissButtonStringTitle, title)
+    func recapScreenDismissButtonTitle(_ title: LocalizedStringResource) -> some View {
+        self.environment(\.recapScreenDismissButtonTitle, title)
     }
 
     /// Configures an `IconFillMode` for the icons displayed on the `RecapScreen`.
@@ -137,26 +132,16 @@ internal extension EnvironmentValues {
 
     // MARK: DismissButtonTitle
 
-    var recapScreenDismissButtonTitle: RecapLocalizedStringKey {
+    var recapScreenDismissButtonTitle: LocalizedStringResource {
         get { self[DismissButtonLocalizedKeyTitle.self] }
         set { self[DismissButtonLocalizedKeyTitle.self] = newValue }
     }
 
     private struct DismissButtonLocalizedKeyTitle: @preconcurrency EnvironmentKey {
-        @MainActor static let defaultValue: RecapLocalizedStringKey = RecapLocalizedStringKey(
-            key: "RECAP.SCREEN.DISMISS.BUTTON.TITLE",
-            bundle: .module,
-            tableName: nil
+        @MainActor static let defaultValue = LocalizedStringResource(
+            "RECAP.SCREEN.DISMISS.BUTTON.TITLE",
+            bundle: .atURL(Bundle.module.bundleURL)
         )
-    }
-
-    var recapScreenDismissButtonStringTitle: String? {
-        get { self[DismissButtonVerbatimStringTitle.self] }
-        set { self[DismissButtonVerbatimStringTitle.self] = newValue }
-    }
-
-    private struct DismissButtonVerbatimStringTitle: EnvironmentKey {
-        static let defaultValue: String? = nil
     }
 
     // MARK: DismissAction

--- a/Sources/Recap/Public/View+Recap.swift
+++ b/Sources/Recap/Public/View+Recap.swift
@@ -33,6 +33,16 @@ public extension View {
         )
     }
 
+    /// Configures a custom localized title for the `RecapScreen` dismiss button.
+    func recapScreenDismissButtonTitle(_ titleKey: LocalizedStringKey, in bundle: Bundle = .main, tableName: String? = nil) -> some View {
+        self.environment(\.recapScreenDismissButtonTitle, RecapLocalizedStringKey(key: titleKey, bundle: bundle, tableName: tableName))
+    }
+
+    /// Configures a custom, non-localized title for the `RecapScreen` dismiss button.
+    func recapScreenDismissButtonTitle(_ title: String) -> some View {
+        self.environment(\.recapScreenDismissButtonStringTitle, title)
+    }
+
     /// Configures an `IconFillMode` for the icons displayed on the `RecapScreen`.
     func recapScreenIconFillMode(_ style: IconFillMode) -> some View {
         self.environment(\.recapScreenIconFillMode, style)
@@ -123,6 +133,30 @@ internal extension EnvironmentValues {
             backgroundStyle: AnyShapeStyle(Color.blue),
             foregroundStyle: AnyShapeStyle(Color.white)
         )
+    }
+
+    // MARK: DismissButtonTitle
+
+    var recapScreenDismissButtonTitle: RecapLocalizedStringKey {
+        get { self[DismissButtonLocalizedKeyTitle.self] }
+        set { self[DismissButtonLocalizedKeyTitle.self] = newValue }
+    }
+
+    private struct DismissButtonLocalizedKeyTitle: @preconcurrency EnvironmentKey {
+        @MainActor static let defaultValue: RecapLocalizedStringKey = RecapLocalizedStringKey(
+            key: "RECAP.SCREEN.DISMISS.BUTTON.TITLE",
+            bundle: .module,
+            tableName: nil
+        )
+    }
+
+    var recapScreenDismissButtonStringTitle: String? {
+        get { self[DismissButtonVerbatimStringTitle.self] }
+        set { self[DismissButtonVerbatimStringTitle.self] = newValue }
+    }
+
+    private struct DismissButtonVerbatimStringTitle: EnvironmentKey {
+        static let defaultValue: String? = nil
     }
 
     // MARK: DismissAction


### PR DESCRIPTION
This PR adds the ability to customise the title of the dismiss button via either a `LocalisedStringKey` (and optional bundle and table name) or a non-localised `String`.

<img width="466" alt="image" src="https://github.com/user-attachments/assets/c3b6ef46-a86c-417f-a7d5-53e5341d4d4b">

One thing I'm unsure about is having the localised and non-localised variants have the same view modifier name - since `LocalisedStringKey` conforms to `ExpressibleByStringInterpolation` this may lead to some confusion. 